### PR TITLE
Fixing broken README logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # pyzerto-unofficial
-![Zerto Automation API Library Logo!](https://github.com/pilotschenck/pyzerto-unofficial/blob/main/zertoautomationapilibrary-logo.png?raw=true)
+![Zerto Automation API Library Logo!](docs/zertoautomationapilibrary-logo.png)
 
 ## Overview
 


### PR DESCRIPTION
The README logo was broken when it was moved to the `docs` folder in my previous pull request.